### PR TITLE
ecdh: add NIST curve P-521 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ num-derive = "0.4.0"
 num-traits = "0.2.6"
 p256 = { version = "^0.13", features = ["ecdsa"] }
 p384 = { version = "^0.13", features = ["ecdsa"] }
+p521 = { version = "^0.13", features = ["ecdh"] }
 rand = "0.8"
 ripemd = { version = "^0.1.3", features = ["oid"] }
 rsa = { version = "0.9.0" }

--- a/src/crypto/ecdh.rs
+++ b/src/crypto/ecdh.rs
@@ -5,7 +5,10 @@ use x25519_dalek::{PublicKey, StaticSecret};
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::crypto::{
-    aes_kw, ecc_curve::ECCCurve, public_key::PublicKeyAlgorithm, sym::SymmetricKeyAlgorithm,
+    aes_kw,
+    ecc_curve::{self, ECCCurve},
+    public_key::PublicKeyAlgorithm,
+    sym::SymmetricKeyAlgorithm,
 };
 use crate::errors::Result;
 use crate::types::{ECDHSecretKey, Mpi, PlainSecretParams, PublicParams};
@@ -19,10 +22,46 @@ const ANON_SENDER: [u8; 20] = [
 ];
 
 const SECRET_KEY_LENGTH: usize = 32;
+const BLOCK_SIZE: usize = 8;
+
+struct KeyPair {
+    p: Vec<u8>,
+    q: Vec<u8>,
+}
 
 /// Generate an ECDH KeyPair.
-/// Currently only support ED25519.
+/// Currently only support X25519.
 pub fn generate_key<R: Rng + CryptoRng>(rng: &mut R) -> (PublicParams, PlainSecretParams) {
+    _generate_key(rng, ECCCurve::Curve25519, SymmetricKeyAlgorithm::AES128)
+}
+
+/// Generate an ECDH KeyPair.
+/// Currently only support X25519 & NIST P-521.
+fn _generate_key<R: Rng + CryptoRng>(
+    rng: &mut R,
+    curve: ECCCurve,
+    alg_sym: SymmetricKeyAlgorithm,
+) -> (PublicParams, PlainSecretParams) {
+    let KeyPair { p, q } = match curve {
+        ECCCurve::Curve25519 => generate_x25519_key(rng),
+        ECCCurve::P521 => generate_p521_key(rng),
+        _ => panic!("Unsupported curve: {:?}", curve),
+    };
+
+    // TODO: make these configurable and/or check for good defaults
+    let hash = HashAlgorithm::default();
+    (
+        PublicParams::ECDH {
+            curve,
+            p: p.into(),
+            hash,
+            alg_sym,
+        },
+        PlainSecretParams::ECDH(Mpi::from_raw(q)),
+    )
+}
+
+fn generate_x25519_key<R: Rng + CryptoRng>(rng: &mut R) -> KeyPair {
     let mut secret_key_bytes = Zeroizing::new([0u8; SECRET_KEY_LENGTH]);
     rng.fill_bytes(&mut *secret_key_bytes);
 
@@ -42,18 +81,23 @@ pub fn generate_key<R: Rng + CryptoRng>(rng: &mut R) -> (PublicParams, PlainSecr
     // Big Endian
     let q = q_raw.into_iter().rev().collect::<Vec<u8>>();
 
-    // TODO: make these configurable and/or check for good defaults
-    let hash = HashAlgorithm::default();
-    let alg_sym = SymmetricKeyAlgorithm::AES128;
-    (
-        PublicParams::ECDH {
-            curve: ECCCurve::Curve25519,
-            p: p.into(),
-            hash,
-            alg_sym,
-        },
-        PlainSecretParams::ECDH(Mpi::from_raw(q)),
-    )
+    KeyPair { p, q }
+}
+
+fn generate_p521_key<R: Rng + CryptoRng>(rng: &mut R) -> KeyPair {
+    use elliptic_curve::{scalar::Scalar, sec1::ToEncodedPoint, Field};
+    use p521::{AffinePoint, NistP521};
+
+    let private_key_scalar = Scalar::<NistP521>::random(rng);
+    let private_bytes = private_key_scalar.to_bytes();
+
+    let base_point = AffinePoint::GENERATOR;
+    let public_key_point = base_point * private_key_scalar;
+
+    KeyPair {
+        p: public_key_point.to_encoded_point(false).to_bytes().to_vec(),
+        q: private_bytes.to_vec(),
+    }
 }
 
 /// Build param for ECDH algorithm (as defined in RFC 6637)
@@ -91,13 +135,18 @@ pub fn decrypt(priv_key: &ECDHSecretKey, mpis: &[Mpi], fingerprint: &[u8]) -> Re
 
     let param = build_ecdh_param(&priv_key.oid, priv_key.alg_sym, priv_key.hash, fingerprint);
 
+    match ecc_curve::ecc_curve_from_oid(&priv_key.oid) {
+        Some(ECCCurve::Curve25519) => decrypt_x25519(priv_key, mpis, &param),
+        Some(ECCCurve::P521) => decrypt_p521(priv_key, mpis, &param),
+        other => bail!("unsupported curve: {:?}", other),
+    }
+}
+
+fn decrypt_x25519(priv_key: &ECDHSecretKey, mpis: &[Mpi], param: &[u8]) -> Result<Vec<u8>> {
     // 33 = 0x40 + 32bits
     ensure_eq!(mpis.len(), 3);
     ensure_eq!(mpis[0].len(), 33, "invalid public point");
-    ensure_eq!(priv_key.secret.len(), 32, "invalid secret point");
-
-    // encrypted and wrapped value derived from the session key
-    let encrypted_session_key = mpis[2].as_bytes();
+    ensure_eq!(priv_key.secret().len(), 32, "invalid secret point");
 
     let their_public = {
         // public part of the ephemeral key (removes 0x40 prefix)
@@ -112,7 +161,7 @@ pub fn decrypt(priv_key: &ECDHSecretKey, mpis: &[Mpi], fingerprint: &[u8]) -> Re
 
     let our_secret = {
         // private key of the recipient.
-        let private_key = &priv_key.secret[..];
+        let private_key = &priv_key.secret();
 
         // create scalar and reverse to little endian
         let mut private_key_le = private_key.iter().rev().cloned().collect::<Vec<u8>>();
@@ -131,10 +180,69 @@ pub fn decrypt(priv_key: &ECDHSecretKey, mpis: &[Mpi], fingerprint: &[u8]) -> Re
         priv_key.hash,
         shared_secret.as_bytes(),
         priv_key.alg_sym.key_size(),
-        &param,
+        param,
     )?;
 
-    // Peform AES Key Unwrap
+    aes_key_unwrap(mpis, &z)
+}
+
+fn decrypt_p521(priv_key: &ECDHSecretKey, mpis: &[Mpi], param: &[u8]) -> Result<Vec<u8>> {
+    use cipher::Unsigned;
+    use p521::{
+        elliptic_curve::{ecdh, Curve, NonZeroScalar},
+        NistP521, PublicKey,
+    };
+
+    ensure_eq!(mpis.len(), 3);
+    // 66 = ((521 + 7) / 8)
+    ensure_eq!(
+        priv_key.secret().len(),
+        <NistP521 as Curve>::FieldBytesSize::USIZE,
+        "invalid secret point"
+    );
+
+    let Ok(their_public) = PublicKey::from_sec1_bytes(mpis[0].as_bytes()) else {
+        bail!("invalid public key");
+    };
+
+    let our_secret = GenericArray::from_slice(priv_key.secret()).to_owned();
+    let Some(private_scalar): Option<NonZeroScalar::<_>> = NonZeroScalar::<p521::NistP521>::from_repr(our_secret).into() else {
+        bail!("invalid private scalar");
+    };
+
+    let public_affine = their_public.as_affine();
+    let shared_secret = ecdh::diffie_hellman(private_scalar, public_affine);
+
+    // Perform key derivation
+    let z = kdf(
+        priv_key.hash,
+        shared_secret.raw_secret_bytes().as_slice(),
+        priv_key.alg_sym.key_size(),
+        param,
+    )?;
+
+    aes_key_unwrap(mpis, &z)
+}
+
+/// Key Derivation Function for ECDH (as defined in RFC 6637).
+/// <https://tools.ietf.org/html/rfc6637#section-7>
+fn kdf(hash: HashAlgorithm, x: &[u8], length: usize, param: &[u8]) -> Result<Vec<u8>> {
+    let prefix = [0, 0, 0, 1];
+
+    let values: [&[u8]; 3] = [&prefix, x, param];
+    let data = values.concat();
+
+    let mut digest = hash.digest(&data)?;
+    digest.truncate(length);
+
+    Ok(digest)
+}
+
+/// Perform AES Key Unwrap
+fn aes_key_unwrap(mpis: &[Mpi], z: &[u8]) -> Result<Vec<u8>> {
+    // encrypted and wrapped value derived from the session key
+    let encrypted_session_key = mpis[2].as_bytes();
+
     let encrypted_key_len: usize = match mpis[1].first() {
         Some(l) => *l as usize,
         None => 0,
@@ -144,16 +252,15 @@ pub fn decrypt(priv_key: &ECDHSecretKey, mpis: &[Mpi], fingerprint: &[u8]) -> Re
     encrypted_session_key_vec[(encrypted_key_len - encrypted_session_key.len())..]
         .copy_from_slice(encrypted_session_key);
 
-    let mut decrypted_key_padded = aes_kw::unwrap(&z, &encrypted_session_key_vec)?;
+    let mut decrypted_key_padded = aes_kw::unwrap(z, &encrypted_session_key_vec)?;
     // PKCS5 unpadding (PKCS5 is PKCS7 with a blocksize of 8)
     {
         let len = decrypted_key_padded.len();
-        let block_size = 8;
-        ensure!(len % block_size == 0, "invalid key length {}", len);
+        ensure!(len % BLOCK_SIZE == 0, "invalid key length {}", len);
         ensure!(!decrypted_key_padded.is_empty(), "empty key is not valid");
 
         // grab the last block
-        let offset = len - block_size;
+        let offset = len - BLOCK_SIZE;
         let last_block = GenericArray::<u8, U8>::from_slice(&decrypted_key_padded[offset..]);
         let unpadded_last_block = Pkcs7::unpad(last_block)?;
         let unpadded_len = offset + unpadded_last_block.len();
@@ -163,18 +270,10 @@ pub fn decrypt(priv_key: &ECDHSecretKey, mpis: &[Mpi], fingerprint: &[u8]) -> Re
     Ok(decrypted_key_padded)
 }
 
-/// Key Derivation Function for ECDH (as defined in RFC 6637).
-/// https://tools.ietf.org/html/rfc6637#section-7
-fn kdf(hash: HashAlgorithm, x: &[u8; 32], length: usize, param: &[u8]) -> Result<Vec<u8>> {
-    let prefix = vec![0, 0, 0, 1];
-
-    let values: Vec<&[u8]> = vec![&prefix, x, param];
-    let data = values.concat();
-
-    let mut digest = hash.digest(&data)?;
-    digest.truncate(length);
-
-    Ok(digest)
+struct EncryptionOutput {
+    encoded_public: Vec<u8>,
+    encrypted_key_len: Vec<u8>,
+    encrypted_key: Vec<u8>,
 }
 
 /// ECDH encryption.
@@ -199,6 +298,27 @@ pub fn encrypt<R: CryptoRng + Rng>(
 
     let param = build_ecdh_param(&curve.oid(), alg_sym, hash, fingerprint);
 
+    let EncryptionOutput {
+        encoded_public,
+        encrypted_key_len,
+        encrypted_key,
+    } = match curve {
+        ECCCurve::Curve25519 => encrypt_x25519(rng, alg_sym, hash, q, plain, &param)?,
+        ECCCurve::P521 => encrypt_p521(rng, alg_sym, hash, q, plain, &param)?,
+        _ => bail!("unsupported curve"),
+    };
+
+    Ok(vec![encoded_public, encrypted_key_len, encrypted_key])
+}
+
+fn encrypt_x25519<R: CryptoRng + Rng>(
+    rng: &mut R,
+    alg_sym: SymmetricKeyAlgorithm,
+    hash: HashAlgorithm,
+    q: &[u8],
+    plain: &[u8],
+    param: &[u8],
+) -> Result<EncryptionOutput> {
     ensure_eq!(q.len(), 33, "invalid public key");
 
     let their_public = {
@@ -220,24 +340,10 @@ pub fn encrypt<R: CryptoRng + Rng>(
     let shared_secret = our_secret.diffie_hellman(&their_public);
 
     // Perform key derivation
-    let z = kdf(hash, shared_secret.as_bytes(), alg_sym.key_size(), &param)?;
+    let z = kdf(hash, shared_secret.as_bytes(), alg_sym.key_size(), param)?;
 
-    // PKCS5 padding (PKCS5 is PKCS7 with a blocksize of 8)
-    let len = plain.len();
     let mut plain_padded = plain.to_vec();
-    plain_padded.resize(len + 8, 0);
-
-    let plain_padded_ref = {
-        let pos = len;
-        let block_size = 8;
-        let bs = block_size * (pos / block_size);
-        if plain_padded.len() < bs || plain_padded.len() - bs < block_size {
-            bail!("unable to pad");
-        }
-        let buf = GenericArray::<u8, U8>::from_mut_slice(&mut plain_padded[bs..bs + block_size]);
-        Pkcs7::pad(buf, pos - bs);
-        &plain_padded[..bs + block_size]
-    };
+    let plain_padded_ref = pad(&mut plain_padded)?;
 
     // Peform AES Key Wrap
     let encrypted_key = aes_kw::wrap(&z, plain_padded_ref)?;
@@ -249,7 +355,71 @@ pub fn encrypt<R: CryptoRng + Rng>(
 
     let encrypted_key_len = vec![u8::try_from(encrypted_key.len())?];
 
-    Ok(vec![encoded_public, encrypted_key_len, encrypted_key])
+    Ok(EncryptionOutput {
+        encoded_public,
+        encrypted_key_len,
+        encrypted_key,
+    })
+}
+
+fn encrypt_p521<R: CryptoRng + Rng>(
+    rng: &mut R,
+    alg_sym: SymmetricKeyAlgorithm,
+    hash: HashAlgorithm,
+    q: &[u8],
+    plain: &[u8],
+    param: &[u8],
+) -> Result<EncryptionOutput> {
+    use p521::{ecdh::EphemeralSecret, EncodedPoint, PublicKey};
+
+    let their_public = PublicKey::from_sec1_bytes(q)?;
+
+    let our_secret = EphemeralSecret::random(rng);
+
+    // derive shared secret
+    let shared_secret = our_secret.diffie_hellman(&their_public);
+
+    let z = kdf(
+        hash,
+        shared_secret.raw_secret_bytes().as_ref(),
+        alg_sym.key_size(),
+        param,
+    )?;
+
+    let mut plain_padded = plain.to_vec();
+    let plain_padded_ref = pad(&mut plain_padded)?;
+
+    // Perform AES Key Wrap
+    let encrypted_key = aes_kw::wrap(&z, plain_padded_ref)?;
+
+    // Public point gets encoded with prefix with 0x04
+    let encoded_public = EncodedPoint::from(PublicKey::from(&our_secret))
+        .to_bytes()
+        .to_vec();
+
+    let encrypted_key_len = vec![u8::try_from(encrypted_key.len())?];
+
+    Ok(EncryptionOutput {
+        encoded_public,
+        encrypted_key_len,
+        encrypted_key,
+    })
+}
+
+/// PKCS5 pads the plaintext and returns the block-aligned slice of the padded plaintext
+fn pad(plain: &mut Vec<u8>) -> Result<&[u8]> {
+    // PKCS5 padding (PKCS5 is PKCS7 with a blocksize of 8)
+    let len = plain.len();
+    plain.resize(len + BLOCK_SIZE, 0);
+
+    let pos = len;
+    let bs = BLOCK_SIZE * (pos / BLOCK_SIZE);
+    if plain.len() < bs || plain.len() - bs < BLOCK_SIZE {
+        bail!("unable to pad");
+    }
+    let buf = GenericArray::<u8, U8>::from_mut_slice(&mut plain[bs..][..BLOCK_SIZE]);
+    Pkcs7::pad(buf, pos - bs);
+    Ok(&plain[..bs + BLOCK_SIZE])
 }
 
 #[cfg(test)]
@@ -263,11 +433,17 @@ mod tests {
 
     use crate::types::{PublicParams, SecretKeyRepr};
 
-    #[test]
-    fn test_encrypt_decrypt() {
-        let mut rng = ChaChaRng::from_seed([0u8; 32]);
+    fn encrypt_decrypt<F>(key_gen: F, curve: ECCCurve, alg_sym: SymmetricKeyAlgorithm)
+    where
+        F: FnOnce(
+            &mut ChaChaRng,
+            ECCCurve,
+            SymmetricKeyAlgorithm,
+        ) -> (PublicParams, PlainSecretParams),
+    {
+        let mut rng = ChaChaRng::from_seed([1u8; 32]);
 
-        let (pkey, skey) = generate_key(&mut rng);
+        let (pkey, skey) = key_gen(&mut rng, curve, alg_sym);
 
         for text_size in 1..239 {
             for _i in 0..10 {
@@ -306,5 +482,45 @@ mod tests {
                 assert_eq!(&plain[..], &decrypted[..]);
             }
         }
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_x25519_aes128() {
+        // Ensure that we still exercise the publicly exposed [`generate_key`].
+        let key_gen = |rng: &mut ChaChaRng, _curve: _, _sym_alg: _| generate_key(rng);
+        encrypt_decrypt(key_gen, ECCCurve::Curve25519, SymmetricKeyAlgorithm::AES128);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_x25519_aes192() {
+        encrypt_decrypt(
+            _generate_key,
+            ECCCurve::Curve25519,
+            SymmetricKeyAlgorithm::AES192,
+        );
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_x25519_aes256() {
+        encrypt_decrypt(
+            _generate_key,
+            ECCCurve::Curve25519,
+            SymmetricKeyAlgorithm::AES128,
+        );
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_p521_aes128() {
+        encrypt_decrypt(_generate_key, ECCCurve::P521, SymmetricKeyAlgorithm::AES128);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_p521_aes192() {
+        encrypt_decrypt(_generate_key, ECCCurve::P521, SymmetricKeyAlgorithm::AES192);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_p521_aes256() {
+        encrypt_decrypt(_generate_key, ECCCurve::P521, SymmetricKeyAlgorithm::AES256);
     }
 }


### PR DESCRIPTION
Adds support for NIST curve P-521 for ECDH operations.

The approach for this PR is to:
- Prioritize following the existing coding style
- Avoid introducing unnecessary duplicated code
    - There is a bit of duplicate code that could be avoided but would add some cognitive complexity where this crate appears to value keeping things straightforward & readable
- Avoid breaking changes as much as possible
- Keep the delta as minimal as reasonable

## Breaking change

Changing `ECDHSecretKey` from being a `struct` to an `enum` is a breaking change, but it seems like the most reasonable path forward if this support is to land, and hopefully the impact of this should be fairly small.  By adding `#[non_exhaustive]`  at this time if support for additional curves are added in the future those shouldn't be subsequent breaking changes.

## `generate_key` panic

The handling of `generate_key` is something I'd want to discuss with the crate author to see how they'd prefer to handle it.  The panic introduced in `_generate_key` can't occur at present since the only non-test & publicly exposed means of hitting this function are through `generate_key` which supplies a supported curve, but it is still not the most ideal.  There are ways to avoid this & still keeping things infallible but it requires some additional restructuring that further expands the delta, so I'm keeping the delta minimal for now.

## References
- Elliptic Curve Cryptography (ECC) in OpenPGP: https://datatracker.ietf.org/doc/html/rfc6637
- OpenPGP Message Format: https://datatracker.ietf.org/doc/html/rfc4880